### PR TITLE
Fix existing lint, dependency, and Keycloak CI failures

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,9 +24,10 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          # shinytest2 >= 0.5.0 requires testthat >= 3.3.1. Keep the
-          # minimum-testthat job on the last compatible shinytest2 release.
-          - {os: ubuntu-latest,   r: 'release', testthat: 'testthat@3.2.2', shinytest2: 'shinytest2@0.4.1'}
+          # testthat 3.2.2 uses R internals removed in R 4.6, and
+          # shinytest2 >= 0.5.0 requires testthat >= 3.3.1. Keep this
+          # minimum-testthat job on compatible R and shinytest2 versions.
+          - {os: ubuntu-latest,   r: '4.5', testthat: 'testthat@3.2.2', shinytest2: 'shinytest2@0.4.1'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,7 +24,9 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: 'release', testthat: 'testthat@3.2.2'}
+          # shinytest2 >= 0.5.0 requires testthat >= 3.3.1. Keep the
+          # minimum-testthat job on the last compatible shinytest2 release.
+          - {os: ubuntu-latest,   r: 'release', testthat: 'testthat@3.2.2', shinytest2: 'shinytest2@0.4.1'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -52,12 +54,17 @@ jobs:
           extra-packages: |
             any::rcmdcheck
             ${{ matrix.config.testthat || 'any::testthat' }}
+            ${{ matrix.config.shinytest2 || 'any::shinytest2' }}
           needs: check
 
-      - name: Verify minimum testthat version
+      - name: Verify minimum testthat dependency versions
         if: matrix.config.testthat != ''
         shell: Rscript {0}
-        run: stopifnot(packageVersion("testthat") == "3.2.2")
+        run: |
+          stopifnot(
+            packageVersion("testthat") == "3.2.2",
+            packageVersion("shinytest2") == "0.4.1"
+          )
 
       - uses: r-lib/actions/check-r-package@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
         with:

--- a/R/utils__diagnostic_text.R
+++ b/R/utils__diagnostic_text.R
@@ -109,16 +109,6 @@ is_oauth_error_text <- function(value) {
     isTRUE(grepl("^[\\x20-\\x21\\x23-\\x5B\\x5D-\\x7E]*$", value, perl = TRUE))
 }
 
-#' Escape diagnostic text for CLI formatting
-#'
-#' Keeps untrusted braces literal when a diagnostic becomes a condition bullet.
-#' @param value Sanitized text.
-#' @return Text with literal braces escaped.
-#' @keywords internal
-#' @noRd
-escape_diagnostic_markup <- function(value) {
-  gsub("}", "}}", gsub("{", "{{", value, fixed = TRUE), fixed = TRUE)
-}
 # Keep received protocol values out of ordinary conditions. Explicit exposure
 # adds bounded literal data; condition constructors never interpolate it.
 protocol_diagnostic_message <- function(message, received) {

--- a/integration/keycloak/test_integration_keycloak_jar_unhappy.R
+++ b/integration/keycloak/test_integration_keycloak_jar_unhappy.R
@@ -107,7 +107,10 @@ testthat::test_that("Keycloak PAR rejects request-object wrong signing key", {
   # A successful control proves this client's PAR authentication and registered
   # Request Object signing key work against the running server.
   control <- make_private_key_jar_client(prov)
-  control_url <- shinyOAuth::prepare_call(control, valid_browser_token())
+  control_url <- shinyOAuth::prepare_call(
+    control,
+    browser_token = paste(rep("ab", 64), collapse = "")
+  )
   testthat::expect_match(control_url, "[?&]request_uri=")
 
   sign_request_object <- shinyOAuth:::build_authorization_request_object


### PR DESCRIPTION
Master currently fails three CI jobs, and PR #17 inherits the same failures. This PR fixes those independently of the token-response feature.

- Remove the unused `escape_diagnostic_markup()` helper flagged by Jarl. Existing literal-diagnostic and exposure tests cover the active formatting paths.
- Run the `testthat@3.2.2` matrix job on R 4.5 with `shinytest2@0.4.1`, and verify both package versions. testthat 3.2.2 fails to load on R 4.6 because its compiled code references the removed `SET_FORMALS` symbol. shinytest2 0.5.0 and later require testthat >= 3.3.1, so the previous dependency set could not resolve. All other jobs continue to use current dependencies.
- Give the Keycloak request-object test's successful control an inline synthetic browser token. Its previous `valid_browser_token()` call referenced a helper unavailable in that test environment.

Baseline failures on master at `16e20157306525a6331297e2b918a9bf235d2d1a`:
- [Jarl unused helper](https://github.com/lukakoning/shinyOAuth/actions/runs/34409145209/job/102659212288)
- [Minimum-testthat dependency conflict](https://github.com/lukakoning/shinyOAuth/actions/runs/34409145207/job/102659212834)
- [Keycloak missing helper](https://github.com/lukakoning/shinyOAuth/actions/runs/34409145211/job/102659212337)

Validation:
- Jarl 0.6.0: all checks passed.
- Existing `diagnostic-exposure`, `literal-protocol-diagnostics`, and `integration-error-policy` tests passed.
- Workflow YAML and changed integration test parse successfully; `git diff --check` passed.
- All 9 GitHub CI checks passed on `820536a9`, including the minimum-testthat job, all five standard platform jobs, Jarl, pkgdown, and live integration.
- Browser and independent authorization-server suites passed with zero skips; the Keycloak suite passed 2,450 expectations with zero failures, warnings, or skips.
- With #17 stacked on these fixes, focused token-response, refresh, and diagnostic tests also passed locally with testthat 3.2.2 on R 4.5.3 (the pre-existing refresh fixture emits one openid-scope warning).

Related: #17.